### PR TITLE
GAT-2672

### DIFF
--- a/functions/helpers.py
+++ b/functions/helpers.py
@@ -169,11 +169,19 @@ def transform_dataset(
                 formatted_dataset["structuralMetadata"] = _format_structural_metadata(
                     formatted_dataset["datasetv2"]["structuralMetadata"]
                 )
-                formatted_dataset["datasetfields"][
-                    "technicaldetails"
-                ] = _format_technical_details(
-                    formatted_dataset["datasetv2"]["structuralMetadata"]
-                )
+            
+                if _keys_exist(dataset, "technicaldetails"):
+                    if len(dataset["technicaldetails"]) > 0:
+                        if verify_technical_metadata_schema_version(validation_schema) == True:
+                            formatted_dataset["datasetfields"][
+                                "technicaldetails"
+                            ] = _format_technical_details(
+                                formatted_dataset["datasetv2"]["structuralMetadata"]
+                            )
+                else:
+                    formatted_dataset["datasetfields"][
+                                "technicaldetails"
+                            ] = []
 
         # Necessary to convert csv or string fields to an array for FE requirements
         csv_or_string_field_paths = [

--- a/functions/validate.py
+++ b/functions/validate.py
@@ -46,3 +46,10 @@ def verify_schema_version(schema_url: str = "") -> bool:
     """
     allowed_versions = ["2.0.0", "2.0.2", "2.1.0", "latest"]
     return bool(re.search("|".join(allowed_versions), schema_url))
+
+def verify_technical_metadata_schema_version(schema_url: str = "") -> bool:
+    """
+    Verify that the supplied schema is either 2.1.0 or latest. Requirement for technical metadata.
+    """
+    allowed_versions = ["2.1.0", "latest"]
+    return bool(re.search("|".join(allowed_versions), schema_url))


### PR DESCRIPTION
Added a function in validate.py, so technical metadata is only relevant if schema version 2.1.0 or latest. Modified code in  in helpers.py: which allows for the technical details (technicalmetadata) as long as it meets the certain conditions, otherwise it remains an empty list.